### PR TITLE
Clean up unnecessary and update necessary dependencies for Node.js v12

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,8 @@ var coffeescript = require('coffee-script');
 var path = require('path');
 var fs = require('fs');
 var calculate = require('sse4_crc32').calculate;
-var mkdirp = require("mkdirp");
-var glob = require("glob");
-var getDirName = require("path").dirname;
-var debug = require('debug')('http');
+var mkdirp = require('mkdirp');
+var getDirName = path.dirname;
 
 var devFlag = false;
 var cacheDirPath = process.cwd() + '/.cache';

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "coffee-script": "*",
     "sse4_crc32": "4.1.0",
     "mkdirp": "0.5.1",
-    "glob": "5.0.15",
-    "path": "0.12.7",
-    "debug": "2.2.0",
-    "btoa": "^1.1.2"
+    "path": "0.12.7"
   },
   "repository": "",
   "author": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "coffee-script": "*",
-    "sse4_crc32": "4.1.0",
+    "sse4_crc32": "^6.0.1",
     "mkdirp": "0.5.1",
     "path": "0.12.7"
   },


### PR DESCRIPTION
[#4399](https://assembla.com/spaces/bhc_igp/tickets/4399). The baseline sse4_crc32 version is incompatible with Node.js v12.
